### PR TITLE
fix: change the dependabot npm schedule to weekly, monday 5:00 and ch…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       - "dependencies"
       - "github-actions"
     open-pull-requests-limit: 5
-    rebase-strategy: "disabled"
+    rebase-strategy: "auto"
     target-branch: "dependabot/github-actions"
 
   - package-ecosystem: "npm"
@@ -23,7 +23,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "04:00"
+      time: "05:00"
       timezone: "Europe/Athens"
     commit-message:
       prefix: "chore"
@@ -34,6 +34,6 @@ updates:
       - "npm"
       - "javascript"
     open-pull-requests-limit: 5
-    rebase-strategy: "disabled"
+    rebase-strategy: "auto"
     target-branch: "dependabot/npm"
     


### PR DESCRIPTION
# Type of Change
Patch

# Description
Change the npm package-ecosystem schedule from weekly, Monday, 4:00am to 5:00am.
Change rebase-strategy of all package-ecosystems from disabled  to auto

