### PR TITLE
fix(AvoidGoingBackwards): Replace gameState.you.body.slice(1) with gameState.you.body[1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ A summary of notable changes in the project.
 ### Feature
 
 - Write a SECURITY.md (@gchatzopoulosCC)
+- Create a getNeck function to get just the neck of the snake (one segment after the head) (@gchatzopoulosCC)
 
 ### Docs
 
@@ -22,6 +23,7 @@ A summary of notable changes in the project.
 - Resolved merge conflicts between `patch/CHANGELOG` and `develop` to keep branches in sync (@sdemba).
 - Add the release version in CHANGELOG on 2025-04-30 (@gchatzopoulosCC)
 - Make esling ignore unecessary files: node_modules/, out/ (@gchatzopoulosCC)
+- Get the neck of the snake instead of the whole tail in avoidGoingBackwards (@gchatzopoulosCC)
 
 ### Refactor
 

--- a/src/common/snake/body.js
+++ b/src/common/snake/body.js
@@ -30,6 +30,31 @@ function getHead(gameState) {
 }
 
 /**
+ * @description Returns the head (first segment) of the snake from the game state.
+ * The head is used for determining the snake's current position and calculating possible moves.
+ *
+ * @param {Object} gameState - The current state of the game.
+ * @param {Object} gameState.you - The player's snake object.
+ * @param {Object[]} gameState.you.body - An array of objects representing the snake's body segments, starting with the head.
+ * @returns {Object} - The head of the snake, represented as an object with `x` and `y` coordinates.
+ *
+ * @example
+ * const gameState = {
+ *   you: {
+ *     body: [
+ *       { x: 1, y: 1 },  // Head
+ *       { x: 1, y: 2 },  // Neck
+ *       { x: 1, y: 3 },  // Rest of the tail
+ *     ],
+ *   },
+ * };
+ * getHead(gameState); // Returns { x: 1, y: 2 }
+ */
+function getNeck(gameState) {
+  return gameState.you.body[1];
+}
+
+/**
  * @description Returns all body segments of the snake excluding the head.
  * The tail segments are used for collision detection to prevent self-collisions.
  *
@@ -54,4 +79,4 @@ function getTail(gameState) {
   return gameState.you.body.slice(1);
 }
 
-export { getHead, getTail };
+export { getHead, getNeck, getTail };

--- a/src/lib/moves/avoidGoingBackwards.js
+++ b/src/lib/moves/avoidGoingBackwards.js
@@ -6,7 +6,7 @@
  * @requires module:src/common/snake/body
  */
 
-import { getHead, getTail } from "../../common/snake/body.js";
+import { getHead, getNeck } from "../../common/snake/body.js";
 
 /**
  * @description This function determines which direction would cause the snake to move backwards
@@ -53,7 +53,7 @@ import { getHead, getTail } from "../../common/snake/body.js";
  */
 export function avoidGoingBackwards(gameState, isMoveSafe) {
   const myHead = getHead(gameState);
-  const myTail = getTail(gameState);
+  const myTail = getNeck(gameState);
 
   if (myTail.x < myHead.x) isMoveSafe.left = false;
   else if (myTail.x > myHead.x) isMoveSafe.right = false;


### PR DESCRIPTION
# Type of Change

fix

# Description

A crucial bug was pushed into the release branch unnoticed. That bug was caused by avoidGoingBackwards taking all the tail segments instead of just the neck