### PR TITLE
fix: Missing repository URL from semantic-release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,6 @@
 {
   "branches": ["main"],
+  "repositoryUrl": "https://github.com/gchatzopoulosCC/battlesnake.git",
   "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
# Type of Change

Patch

# Description

Added the missing repository url in the _.releaserc_

# Related Issues

#98 

